### PR TITLE
chore: add to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ webapp/frontend/dist/
 *.log
 nohup.out
 .DS_Store
+*.md


### PR DESCRIPTION
Adds *.md to the gitignore to prevent internal planning and notes files from being accidentally committed. Already tracked files like README.md are not affected.