### PR TITLE
feat: implement hybrid search using RRF

### DIFF
--- a/webapp/backend/main.py
+++ b/webapp/backend/main.py
@@ -55,6 +55,7 @@ class ChatRequest(BaseModel):
 
 
 ELSER_READY = False  # Flip to True once reindex_elser.py has completed
+# TODO: once ELSER_READY is True and confirmed working, remove this flag and build_retrievers entirely and inline the three retrievers directly into search_wowpedia
 
 
 def build_retrievers(query: str) -> list:


### PR DESCRIPTION
Closes #3 + https://github.com/emalinegayhart/Loremaster/issues/11?issue=emalinegayhart%7CLoremaster%7C14
Contributes to https://github.com/emalinegayhart/Loremaster/issues/11

Replaces the single `multi_match` query with RRF (Reciprocal Rank Fusion) combining two BM25 retrievers and an ELSER sparse vector retriever. The `cross_fields` retriever handles conversational queries by combining scores across title, summary, and content fields. The `best_fields` retriever with fuzziness handles typo tolerance. The ELSER retriever adds semantic understanding once re-indexing is complete.

The ELSER retriever is gated behind an ELSER_READY flag in the backend. Set this to True once `reindex_elser.py` has finished populating the content_sparse field across all articles. 

The BM25-only RRF query is already live and performing well in testing, with "A Call to Ardenweald (Kyrian)" surfacing as the top result for the query that previously returned no relevant context.