### PR TITLE
feat: merge eval infrastructure and notebooks into main

### DIFF
--- a/evals/notebooks/eval.ipynb
+++ b/evals/notebooks/eval.ipynb
@@ -1,0 +1,191 @@
+{
+ "nbformat": 4,
+ "nbformat_minor": 5,
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11"
+  }
+ },
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Loremaster Retrieval Evaluation\n",
+    "\n",
+    "This notebook evaluates and compares five Elasticsearch query strategies against a benchmark dataset of 150 WoW queries.\n",
+    "\n",
+    "## Strategies\n",
+    "\n",
+    "| Strategy | Description |\n",
+    "|---|---|\n",
+    "| `original` | Single `best_fields` query with fuzziness and 75% `minimum_should_match`. The original production query. |\n",
+    "| `cross_fields` | Single `cross_fields` query. Treats all terms as belonging to one combined field across title, summary, and content. |\n",
+    "| `best_fields` | Single `best_fields` query with fuzziness, no `minimum_should_match`. |\n",
+    "| `rrf_bm25` | RRF combining `cross_fields` and `best_fields` retrievers. No ELSER. |\n",
+    "| `rrf_elser` | RRF combining `cross_fields`, `best_fields`, and ELSER sparse vector retrievers. Current production query. |\n",
+    "\n",
+    "## Metrics\n",
+    "\n",
+    "- **Hit@5** — did the expected article appear in the top 5 results?\n",
+    "- **MRR (Mean Reciprocal Rank)** — how highly was the expected article ranked? Score of 1.0 means it was always the top result.\n",
+    "\n",
+    "## Benchmark Dataset\n",
+    "\n",
+    "150 queries across five categories (lore, quest, item, gameplay, long_tail) and two query types (conversational and short). See `evals/data/benchmark.json`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sys, json\n",
+    "from pathlib import Path\n",
+    "sys.path.append(str(Path('../..').resolve()))\n",
+    "\n",
+    "from elasticsearch import Elasticsearch\n",
+    "from config import ES_ENDPOINT, ES_API_KEY, ES_INDEX\n",
+    "from evals.retrieval.strategies import STRATEGIES\n",
+    "from evals.retrieval.metrics import hit_rate, mrr\n",
+    "\n",
+    "es    = Elasticsearch(ES_ENDPOINT, api_key=ES_API_KEY)\n",
+    "TOP_K = 5"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Load Benchmark\n",
+    "\n",
+    "Loads the benchmark dataset and prints a summary of query counts by type."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "benchmark  = json.loads(Path('../../evals/data/benchmark.json').read_text())\n",
+    "queries    = [b['query']    for b in benchmark]\n",
+    "expected   = [b['expected'] for b in benchmark]\n",
+    "categories = [b['category'] for b in benchmark]\n",
+    "types      = [b.get('type', 'conversational') for b in benchmark]\n",
+    "\n",
+    "print(f'Total queries:     {len(benchmark)}')\n",
+    "print(f'Conversational:    {sum(1 for t in types if t == \"conversational\")}')\n",
+    "print(f'Short:             {sum(1 for t in types if t == \"short\")}')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Run All Strategies\n",
+    "\n",
+    "Runs each strategy against all 150 queries and caches the results. This avoids re-querying Elasticsearch for every breakdown section below."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def search(query_body):\n",
+    "    result = es.search(index=ES_INDEX, body={**query_body, 'size': TOP_K, '_source': ['title']})\n",
+    "    return [h['_source']['title'] for h in result['hits']['hits']]\n",
+    "\n",
+    "cached = {}\n",
+    "for name, strategy in STRATEGIES.items():\n",
+    "    print(f'Running {name}...')\n",
+    "    cached[name] = [search(strategy['query'](q)) for q in queries]\n",
+    "print('Done.')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Overall Results\n",
+    "\n",
+    "Hit@5 and MRR across all 150 queries."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(f\"{'Strategy':<20} {'Hit@5':>8}   {'MRR':>8}\")\n",
+    "print('-' * 45)\n",
+    "for name in STRATEGIES:\n",
+    "    hr        = hit_rate(cached[name], expected, k=TOP_K)\n",
+    "    mrr_score = mrr(cached[name], expected, k=TOP_K)\n",
+    "    print(f'{name:<20} {hr:>8.2%}   {mrr_score:>8.3f}')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Per-Category Breakdown\n",
+    "\n",
+    "Results broken down by query category (lore, quest, item, gameplay, long_tail)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for category in sorted(set(categories)):\n",
+    "    indices = [i for i, c in enumerate(categories) if c == category]\n",
+    "    print(f'\\n{category} ({len(indices)} queries)')\n",
+    "    for name in STRATEGIES:\n",
+    "        results   = [cached[name][i] for i in indices]\n",
+    "        exp       = [expected[i] for i in indices]\n",
+    "        hr        = hit_rate(results, exp, k=TOP_K)\n",
+    "        mrr_score = mrr(results, exp, k=TOP_K)\n",
+    "        print(f'  {name:<20} {hr:>8.2%}   MRR {mrr_score:.3f}')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## By Query Type\n",
+    "\n",
+    "Conversational queries (e.g. \"Hey, where do I find...\") vs short direct queries (e.g. \"Arthas death knight lore\"). This breakdown shows how each strategy handles different query styles."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for qtype in sorted(set(types)):\n",
+    "    indices = [i for i, t in enumerate(types) if t == qtype]\n",
+    "    print(f'\\n{qtype} ({len(indices)} queries)')\n",
+    "    for name in STRATEGIES:\n",
+    "        results   = [cached[name][i] for i in indices]\n",
+    "        exp       = [expected[i] for i in indices]\n",
+    "        hr        = hit_rate(results, exp, k=TOP_K)\n",
+    "        mrr_score = mrr(results, exp, k=TOP_K)\n",
+    "        print(f'  {name:<20} {hr:>8.2%}   MRR {mrr_score:.3f}')"
+   ]
+  }
+ ]
+}

--- a/evals/notebooks/results.ipynb
+++ b/evals/notebooks/results.ipynb
@@ -1,0 +1,383 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "82ef33c2",
+   "metadata": {},
+   "source": [
+    "# Loremaster Retrieval Evaluation\n",
+    "\n",
+    "This notebook evaluates and compares five Elasticsearch query strategies against a benchmark dataset of 150 WoW queries.\n",
+    "\n",
+    "## Strategies\n",
+    "\n",
+    "| Strategy | Description |\n",
+    "|---|---|\n",
+    "| `original` | Single `best_fields` query with fuzziness and 75% `minimum_should_match`. The original production query. |\n",
+    "| `cross_fields` | Single `cross_fields` query. Treats all terms as belonging to one combined field across title, summary, and content. |\n",
+    "| `best_fields` | Single `best_fields` query with fuzziness, no `minimum_should_match`. |\n",
+    "| `rrf_bm25` | RRF combining `cross_fields` and `best_fields` retrievers. No ELSER. |\n",
+    "| `rrf_elser` | RRF combining `cross_fields`, `best_fields`, and ELSER sparse vector retrievers. Current production query. |\n",
+    "\n",
+    "## Metrics\n",
+    "\n",
+    "- **Hit@5** — did the expected article appear in the top 5 results?\n",
+    "- **MRR (Mean Reciprocal Rank)** — how highly was the expected article ranked? Score of 1.0 means it was always the top result.\n",
+    "\n",
+    "## Benchmark Dataset\n",
+    "\n",
+    "150 queries across five categories (lore, quest, item, gameplay, long_tail) and two query types (conversational and short). See `evals/data/benchmark.json`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "4d520868",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-03-23T09:15:34.218887Z",
+     "iopub.status.busy": "2026-03-23T09:15:34.218766Z",
+     "iopub.status.idle": "2026-03-23T09:15:34.415816Z",
+     "shell.execute_reply": "2026-03-23T09:15:34.415384Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "import sys, json\n",
+    "from pathlib import Path\n",
+    "sys.path.append(str(Path('../..').resolve()))\n",
+    "\n",
+    "from elasticsearch import Elasticsearch\n",
+    "from config import ES_ENDPOINT, ES_API_KEY, ES_INDEX\n",
+    "from evals.retrieval.strategies import STRATEGIES\n",
+    "from evals.retrieval.metrics import hit_rate, mrr\n",
+    "\n",
+    "es    = Elasticsearch(ES_ENDPOINT, api_key=ES_API_KEY)\n",
+    "TOP_K = 5"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "79524cd4",
+   "metadata": {},
+   "source": [
+    "## Load Benchmark\n",
+    "\n",
+    "Loads the benchmark dataset and prints a summary of query counts by type."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "4ae6bb57",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-03-23T09:15:34.417174Z",
+     "iopub.status.busy": "2026-03-23T09:15:34.417103Z",
+     "iopub.status.idle": "2026-03-23T09:15:34.419840Z",
+     "shell.execute_reply": "2026-03-23T09:15:34.419427Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Total queries:     150\n",
+      "Conversational:    100\n",
+      "Short:             50\n"
+     ]
+    }
+   ],
+   "source": [
+    "benchmark  = json.loads(Path('../../evals/data/benchmark.json').read_text())\n",
+    "queries    = [b['query']    for b in benchmark]\n",
+    "expected   = [b['expected'] for b in benchmark]\n",
+    "categories = [b['category'] for b in benchmark]\n",
+    "types      = [b.get('type', 'conversational') for b in benchmark]\n",
+    "\n",
+    "print(f'Total queries:     {len(benchmark)}')\n",
+    "print(f'Conversational:    {sum(1 for t in types if t == \"conversational\")}')\n",
+    "print(f'Short:             {sum(1 for t in types if t == \"short\")}')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1d7f2267",
+   "metadata": {},
+   "source": [
+    "## Run All Strategies\n",
+    "\n",
+    "Runs each strategy against all 150 queries and caches the results. This avoids re-querying Elasticsearch for every breakdown section below."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "a035799b",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-03-23T09:15:34.420866Z",
+     "iopub.status.busy": "2026-03-23T09:15:34.420806Z",
+     "iopub.status.idle": "2026-03-23T09:17:36.166938Z",
+     "shell.execute_reply": "2026-03-23T09:17:36.164697Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Running original...\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Running cross_fields...\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Running best_fields...\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Running rrf_bm25...\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Running rrf_elser...\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Done.\n"
+     ]
+    }
+   ],
+   "source": [
+    "def search(query_body):\n",
+    "    result = es.search(index=ES_INDEX, body={**query_body, 'size': TOP_K, '_source': ['title']})\n",
+    "    return [h['_source']['title'] for h in result['hits']['hits']]\n",
+    "\n",
+    "cached = {}\n",
+    "for name, strategy in STRATEGIES.items():\n",
+    "    print(f'Running {name}...')\n",
+    "    cached[name] = [search(strategy['query'](q)) for q in queries]\n",
+    "print('Done.')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "73cf3321",
+   "metadata": {},
+   "source": [
+    "## Overall Results\n",
+    "\n",
+    "Hit@5 and MRR across all 150 queries."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "bad144e8",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-03-23T09:17:36.174441Z",
+     "iopub.status.busy": "2026-03-23T09:17:36.174190Z",
+     "iopub.status.idle": "2026-03-23T09:17:36.181005Z",
+     "shell.execute_reply": "2026-03-23T09:17:36.180310Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Strategy                Hit@5        MRR\n",
+      "---------------------------------------------\n",
+      "original               36.67%      0.349\n",
+      "cross_fields           88.67%      0.822\n",
+      "best_fields            67.33%      0.581\n",
+      "rrf_bm25               83.33%      0.739\n",
+      "rrf_elser              91.33%      0.808\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(f\"{'Strategy':<20} {'Hit@5':>8}   {'MRR':>8}\")\n",
+    "print('-' * 45)\n",
+    "for name in STRATEGIES:\n",
+    "    hr        = hit_rate(cached[name], expected, k=TOP_K)\n",
+    "    mrr_score = mrr(cached[name], expected, k=TOP_K)\n",
+    "    print(f'{name:<20} {hr:>8.2%}   {mrr_score:>8.3f}')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d89cee71",
+   "metadata": {},
+   "source": [
+    "## Per-Category Breakdown\n",
+    "\n",
+    "Results broken down by query category (lore, quest, item, gameplay, long_tail)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "1210db94",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-03-23T09:17:36.183286Z",
+     "iopub.status.busy": "2026-03-23T09:17:36.183146Z",
+     "iopub.status.idle": "2026-03-23T09:17:36.188862Z",
+     "shell.execute_reply": "2026-03-23T09:17:36.188244Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "gameplay (30 queries)\n",
+      "  original               33.33%   MRR 0.300\n",
+      "  cross_fields           93.33%   MRR 0.858\n",
+      "  best_fields            70.00%   MRR 0.557\n",
+      "  rrf_bm25               83.33%   MRR 0.714\n",
+      "  rrf_elser              96.67%   MRR 0.833\n",
+      "\n",
+      "item (30 queries)\n",
+      "  original               36.67%   MRR 0.344\n",
+      "  cross_fields           96.67%   MRR 0.911\n",
+      "  best_fields            73.33%   MRR 0.673\n",
+      "  rrf_bm25               96.67%   MRR 0.859\n",
+      "  rrf_elser              96.67%   MRR 0.868\n",
+      "\n",
+      "long_tail (15 queries)\n",
+      "  original               33.33%   MRR 0.333\n",
+      "  cross_fields           93.33%   MRR 0.900\n",
+      "  best_fields            73.33%   MRR 0.617\n",
+      "  rrf_bm25               93.33%   MRR 0.867\n",
+      "  rrf_elser              93.33%   MRR 0.933\n",
+      "\n",
+      "lore (45 queries)\n",
+      "  original               42.22%   MRR 0.411\n",
+      "  cross_fields           84.44%   MRR 0.764\n",
+      "  best_fields            60.00%   MRR 0.571\n",
+      "  rrf_bm25               77.78%   MRR 0.663\n",
+      "  rrf_elser              88.89%   MRR 0.772\n",
+      "\n",
+      "quest (30 queries)\n",
+      "  original               33.33%   MRR 0.317\n",
+      "  cross_fields           80.00%   MRR 0.744\n",
+      "  best_fields            66.67%   MRR 0.508\n",
+      "  rrf_bm25               73.33%   MRR 0.692\n",
+      "  rrf_elser              83.33%   MRR 0.715\n"
+     ]
+    }
+   ],
+   "source": [
+    "for category in sorted(set(categories)):\n",
+    "    indices = [i for i, c in enumerate(categories) if c == category]\n",
+    "    print(f'\\n{category} ({len(indices)} queries)')\n",
+    "    for name in STRATEGIES:\n",
+    "        results   = [cached[name][i] for i in indices]\n",
+    "        exp       = [expected[i] for i in indices]\n",
+    "        hr        = hit_rate(results, exp, k=TOP_K)\n",
+    "        mrr_score = mrr(results, exp, k=TOP_K)\n",
+    "        print(f'  {name:<20} {hr:>8.2%}   MRR {mrr_score:.3f}')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9bef73d5",
+   "metadata": {},
+   "source": [
+    "## By Query Type\n",
+    "\n",
+    "Conversational queries (e.g. \"Hey, where do I find...\") vs short direct queries (e.g. \"Arthas death knight lore\"). This breakdown shows how each strategy handles different query styles."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "6cdeebd5",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-03-23T09:17:36.190512Z",
+     "iopub.status.busy": "2026-03-23T09:17:36.190391Z",
+     "iopub.status.idle": "2026-03-23T09:17:36.195472Z",
+     "shell.execute_reply": "2026-03-23T09:17:36.194908Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "conversational (100 queries)\n",
+      "  original               11.00%   MRR 0.110\n",
+      "  cross_fields           84.00%   MRR 0.770\n",
+      "  best_fields            56.00%   MRR 0.461\n",
+      "  rrf_bm25               77.00%   MRR 0.668\n",
+      "  rrf_elser              87.00%   MRR 0.758\n",
+      "\n",
+      "short (50 queries)\n",
+      "  original               88.00%   MRR 0.827\n",
+      "  cross_fields           98.00%   MRR 0.927\n",
+      "  best_fields            90.00%   MRR 0.820\n",
+      "  rrf_bm25               96.00%   MRR 0.880\n",
+      "  rrf_elser             100.00%   MRR 0.908\n"
+     ]
+    }
+   ],
+   "source": [
+    "for qtype in sorted(set(types)):\n",
+    "    indices = [i for i, t in enumerate(types) if t == qtype]\n",
+    "    print(f'\\n{qtype} ({len(indices)} queries)')\n",
+    "    for name in STRATEGIES:\n",
+    "        results   = [cached[name][i] for i in indices]\n",
+    "        exp       = [expected[i] for i in indices]\n",
+    "        hr        = hit_rate(results, exp, k=TOP_K)\n",
+    "        mrr_score = mrr(results, exp, k=TOP_K)\n",
+    "        print(f'  {name:<20} {hr:>8.2%}   MRR {mrr_score:.3f}')"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Closes: https://github.com/emalinegayhart/Loremaster/issues/22
Contributes to: https://github.com/emalinegayhart/Loremaster/issues/16

**Changes:**
Adds two notebooks to evals/notebooks:

- `eval.ipynb` is a clean runnable notebook with markdown explanations for each section covering setup, benchmark loading, running all strategies, overall results, per-category breakdown, and query type breakdown.
- `results.ipynb` is the same notebook with all outputs already rendered so results are readable on GitHub without running anything.