### PR TITLE
(feat): add oauth config, fix redirect uris, and add db retry logic

### DIFF
--- a/webapp/backend/config.py
+++ b/webapp/backend/config.py
@@ -1,0 +1,14 @@
+import os
+
+NEON_CONNECTION_STRING = os.getenv(
+    "NEON_CONNECTION_STRING",
+    "postgresql://user:password@localhost/loremaster"
+)
+
+ES_ENDPOINT = os.getenv("ES_ENDPOINT", "http://localhost:9200")
+ES_API_KEY = os.getenv("ES_API_KEY", "")
+ES_INDEX = os.getenv("ES_INDEX", "wowpedia")
+
+ANTHROPIC_API_KEY = os.getenv("ANTHROPIC_API_KEY", "")
+
+ELSER_READY = os.getenv("ELSER_READY", "False").lower() == "true"

--- a/webapp/backend/db.py
+++ b/webapp/backend/db.py
@@ -1,7 +1,12 @@
+import logging
+import time
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
+from sqlalchemy.exc import OperationalError, DatabaseError
 from sqlmodel import SQLModel, Session
 from services.secret_service import SecretService
+
+log = logging.getLogger(__name__)
 
 # Initialize secrets first
 SecretService.load()
@@ -28,10 +33,20 @@ def get_session():
         yield session
 
 
-def init_db():
-    """Create all tables"""
-    SQLModel.metadata.create_all(engine)
-    print("✅ Database initialized")
+def init_db(retries=3, delay=2):
+    """Create all tables with retry logic"""
+    for attempt in range(retries):
+        try:
+            SQLModel.metadata.create_all(engine)
+            print("✅ Database initialized")
+            return
+        except (OperationalError, DatabaseError) as e:
+            if attempt < retries - 1:
+                log.warning(f"Database unavailable (attempt {attempt+1}/{retries}), retrying in {delay}s: {e}")
+                time.sleep(delay)
+            else:
+                log.warning(f"Database unavailable after {retries} attempts: {e}")
+                raise
 
 
 def drop_all_tables():

--- a/webapp/backend/main.py
+++ b/webapp/backend/main.py
@@ -31,7 +31,11 @@ from routes.auth import router as auth_router
 from middleware.auth_middleware import TokenExtractionMiddleware, ProtectedRouteMiddleware
 
 SecretService.load()
-init_db()
+
+try:
+    init_db()
+except Exception as e:
+    log.warning(f"Database initialization failed: {e}")
 
 logging.basicConfig(level=logging.INFO)
 log = logging.getLogger(__name__)

--- a/webapp/backend/routes/auth.py
+++ b/webapp/backend/routes/auth.py
@@ -8,6 +8,7 @@ Handles:
 - POST /api/auth/logout - Clear tokens
 """
 
+import os
 import logging
 from fastapi import APIRouter, Response, HTTPException, Depends, status, Request
 from fastapi.responses import RedirectResponse
@@ -108,7 +109,8 @@ async def google_callback(
         access_token = jwt_service.create_access_token(user_id=user.id)
         refresh_token = jwt_service.create_refresh_token(user_id=user.id)
         
-        response = RedirectResponse(url="/app", status_code=status.HTTP_302_FOUND)
+        frontend_url = os.getenv("FRONTEND_URL", "http://localhost:5173")
+        response = RedirectResponse(url=f"{frontend_url}/auth/callback", status_code=status.HTTP_302_FOUND)
         
         response.set_cookie(
             key="access_token",

--- a/webapp/backend/services/secret_service.py
+++ b/webapp/backend/services/secret_service.py
@@ -27,7 +27,7 @@ class SecretService:
         """Load all secrets from environment"""
         cls.GOOGLE_CLIENT_ID = os.getenv("GOOGLE_CLIENT_ID")
         cls.GOOGLE_CLIENT_SECRET = os.getenv("GOOGLE_CLIENT_SECRET")
-        cls.GOOGLE_REDIRECT_URI = os.getenv("GOOGLE_REDIRECT_URI", "http://localhost:8000/api/auth/callback")
+        cls.GOOGLE_REDIRECT_URI = os.getenv("GOOGLE_REDIRECT_URI", "http://localhost:8080/api/auth/google/callback")
         
         cls.JWT_SECRET_KEY = os.getenv("JWT_SECRET_KEY")
         


### PR DESCRIPTION
- Added config.py for environment-based configuration. 
- Fixed GOOGLE_REDIRECT_URI to use correct port (8080) and endpoint (/api/auth/google/callback). 
- Updated OAuth callback to redirect to frontend's /auth/callback with configurable FRONTEND_URL env var (defaults to http://localhost:5173 for local dev). 
- Added retry logic to init_db() to handle temporary database unavailability during startup (3 retries with 2-second delays).