### PR TITLE
add connection pooling to database engine

### DIFF
--- a/webapp/backend/db.py
+++ b/webapp/backend/db.py
@@ -11,12 +11,16 @@ log = logging.getLogger(__name__)
 # Initialize secrets first
 SecretService.load()
 
-# Create engine
+# Create engine with connection pooling
 engine = create_engine(
     SecretService.DATABASE_URL,
     echo=False,
     future=True,
     pool_pre_ping=True,  # Test connections before using them
+    pool_size=10,  # Number of connections to keep in the pool
+    max_overflow=20,  # Additional connections beyond pool_size
+    pool_recycle=3600,  # Recycle connections after 1 hour to avoid stale connections
+    pool_timeout=30,  # Timeout waiting for a connection (seconds)
 )
 
 # Session factory


### PR DESCRIPTION
**Solves:** https://github.com/emalinegayhart/Loremaster/issues/146

This PR implements the SQLAlchemy connection pooling to reuse database connections instead of creating new ones for each request. This also allows there to always be a connection ready, so the database will never turn off.

**Configuration:**
- pool_size=10: Keep 10 pre-made connections ready
- max_overflow=20: Allow up to 20 additional temporary connections if needed
- pool_recycle=3600: Recycle connections after 1 hour to prevent stale connections
- pool_timeout=30: Wait up to 30 seconds for an available connection