### PR TITLE
Change elasticsearch keep-alive interval

### DIFF
--- a/webapp/backend/services/elasticsearch_service.py
+++ b/webapp/backend/services/elasticsearch_service.py
@@ -13,7 +13,7 @@ class ElasticsearchService:
         while True:
             try:
                 self.es.info()
-                await asyncio.sleep(1500)
+                await asyncio.sleep(540)
             except Exception as e:
                 log.error("Failed to keep ES alive: %s", e)
                 await asyncio.sleep(5)


### PR DESCRIPTION
contributes to: https://github.com/emalinegayhart/Loremaster/issues/156

es can sleep after 30 min, but railway can sleep after 10 minutes

changing this to prevent cold starts